### PR TITLE
feat: add option to see latest docs build on branch

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -38,7 +38,7 @@ Deno.serve(async (req) => {
           console.log({owner, repo, branch});
           target_file = groups[4];
           try {
-              for (let page=0; page < 5; page++) {
+              for (let page=1; page < 6; page++) {
                   const artifacts = (await (await fetch(
                       `https://api.github.com/repos/${owner}/${repo}/actions/artifacts?name=docs_html&page=${page}`,
                       opts,

--- a/main.ts
+++ b/main.ts
@@ -6,12 +6,6 @@ console.log("Found token:", !!token)
 
 const zipReaderMap = new Map();
 
-const latest_docs_cache = new Map();
-const clear_cache = setInterval(
-    () => latest_docs_cache.clear(),
-    60 * 1000,
-);
-
 Deno.serve(async (req) => {
   const url = new URL(req.url);
 

--- a/main.ts
+++ b/main.ts
@@ -6,19 +6,76 @@ console.log("Found token:", !!token)
 
 const zipReaderMap = new Map();
 
+const latest_docs_cache = new Map();
+const clear_cache = setInterval(
+    () => latest_docs_cache.clear(),
+    60 * 1000,
+);
 
 Deno.serve(async (req) => {
   const url = new URL(req.url);
 
-  const groups = url.pathname.match(/\/([^\/]*)\/([^\/]*)\/.*artifacts\/(\d{10})\/?(.*)/);
-  if (groups == null) {
-      return new Response("No artifact path provided. Provide a valid github artifact url.", { status: 404 });
-  }
-  const owner = groups[1];
-  const repo = groups[2];
-  const artifact = groups[3];
-  let target_file = groups[4];
+  const opts = {
+    headers: {
+      Authorization: `token ${token}`,
+    },
+  };
 
+  let remote_url, target_file = '', cache_control = "max-age=31536000";
+
+  // Look for url like org/repo/artifacts/xxxxx/file
+  const groups = url.pathname.match(/\/([^\/]*)\/([^\/]*)\/.*artifacts\/(\d{10})\/?(.*)/);
+  if (groups !== null) {
+      const owner = groups[1];
+      const repo = groups[2];
+      const artifact = groups[3];
+      console.log({owner, repo, artifact});
+      target_file = groups[4];
+      remote_url = `https://api.github.com/repos/${owner}/${repo}/actions/artifacts/${artifact}/zip`
+  }
+  // If not found, look for url like org/repo/branch/file
+  // If it matches, find the latest action run in the repo on the branch and use its first artifact
+  if (remote_url === undefined) {
+      const groups = url.pathname.match(/\/([^\/]*)\/([^\/]*)\/([^\/]*)\/?(.*)/);
+      if (groups !== null) {
+          const owner = groups[1];
+          const repo = groups[2];
+          const branch = groups[3];
+          console.log({owner, repo, branch});
+          target_file = groups[4];
+          const key = [owner, repo, branch].join('/');
+          for (let ntry=0; ntry < 3; ntry++) {
+              try {
+                  if (!latest_docs_cache.has(key)) {
+                      console.log("Querying github for latest docs build");
+                      const latest_artifact_url = (await (await fetch(
+                          `https://api.github.com/repos/${owner}/${repo}/actions/runs?branch=${branch}&per_page=1`,
+                          opts,
+                      )).json()).workflow_runs[0].artifacts_url;
+                      latest_docs_cache.set(
+                          key,
+                          (await (await fetch(
+                              latest_artifact_url,
+                              opts,
+                          )).json()).artifacts[0].archive_download_url
+                      );
+                      console.log('Cache state after update:', latest_docs_cache);
+                  }
+              } catch (e) {
+                  console.log("Error when fetching latest artifact from branch ", e);
+                  continue
+              }
+              remote_url = latest_docs_cache.get(key);
+              cache_control = "max-age=300"
+              break;
+          }
+      }
+  }
+  if (remote_url === undefined) {
+      return new Response(
+          "No artifact path provided. Provide a valid github artifact url.", { status: 404 }
+      );
+  }
   if (target_file == '') {
       target_file = 'index.html';
 
@@ -26,22 +83,13 @@ Deno.serve(async (req) => {
           return Response.redirect(req.url + '/');
       }
   }
-  console.log({owner, repo, artifact});
-
-  const remote_url = `https://api.github.com/repos/${owner}/${repo}/actions/artifacts/${artifact}/zip`
   console.log(remote_url, target_file);
-  const opts = {
-    headers: {
-      Authorization: `token ${token}`,
-    },
-  };
   
   if (!zipReaderMap.has(remote_url)) {
       const httpReader = new HttpRangeReader(remote_url, opts);
       zipReaderMap.set(remote_url, new ZipReader(httpReader));
   }
   const zipReader = zipReaderMap.get(remote_url);
-
   const entries = await zipReader.getEntries().catch(err => {console.error(err); return [];});
   const targetEntry = entries.find((entry) => entry.filename === target_file);
 
@@ -53,12 +101,12 @@ Deno.serve(async (req) => {
   console.log(`Found "${target_file}" in ZIP archive. Streaming...`);
 
   const stream = new TransformStream();
-  targetEntry.getData(stream);
+  targetEntry.getData(stream).catch(err => console.log("Stream was interruped", err));
 
   const ext = mime.contentType(target_file.split('.').slice(-1)[0]);
 
   return new Response(
       stream.readable,
-      { headers: { "Content-Type": ext, "Cache-Control": "max-age=31536000"}}
+      { headers: { "Content-Type": ext, "Cache-Control": cache_control}}
   );
 });


### PR DESCRIPTION
Lets us see the latest built docs on a particular branch by visiting (for example)
https://remote-unzip-1ehyjt4pqjp4.deno.dev/scipp/essreflectometry/improve-docs/
(url has format `remote-unzip.deno.dev/{org}/{repo}/{branch}`)

It is useful because the page at that url will get continually updated as new changes arrive on the branch,
so to see the latest changes we don't need to go into the latest workflow summary page and copy the url from there.

The server looks at the latest github ~100 actions in the repo and redirects to the first docs build on the requested branch

* the latest docs build failed or
* the latest docs build is not finished yet 

then nothing will be retrieved.

Note that the token that is used by this tool has no permissions, and is therefore not able to see our private repos.
