### PR TITLE
fix: handle different docs artifact names for scipp

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -40,9 +40,7 @@ Deno.serve(async (req) => {
           try {
               // Retreive relatively few per page - hopefully we won't need to fetch many anyway, so it won't increase latency much.
               const per_page = 10;
-              // Retreive runs on branch.
-              // For each run, retreive the first artifact that has "docs_html" name.
-              // Retreive artifacts until we find the latest on branch.
+              // Retreive runs on branch, for each run, retreive the first artifact that has "docs_html" name.
               // Assume that one of the first per_page * 10 workflow runs has a docs build.
               for (let page=1; page < 10; page++) {
                   const runs = (await (await fetch(

--- a/main.ts
+++ b/main.ts
@@ -59,20 +59,22 @@ Deno.serve(async (req) => {
                   `https://api.github.com/repos/${owner}/${repo}/releases/tags/${tag}`,
                   opts,
               )).json());
-              const assets = await (await fetch(release.assets_url)).json();
-              for (const asset of assets) {
-                  if (asset.name.match(/documentation.*/)) {
-                      if (target_file == '') {
-                          target_file = `documentation-${tag}/index.html`;
+              if (release.assets_url) {
+                  const assets = await (await fetch(release.assets_url)).json();
+                  for (const asset of assets) {
+                      if (asset.name.match(/documentation.*/)) {
+                          if (target_file == '') {
+                              target_file = `documentation-${tag}/index.html`;
+                          }
+                          console.log(
+                              'Redirecting to',
+                              `${url.origin}/${owner}/${repo}/assets/${asset.id}/${target_file}`,
+                          );
+                          return Response.redirect(
+                              `${url.origin}/${owner}/${repo}/assets/${asset.id}/${target_file}`,
+                               302,
+                          );
                       }
-                      console.log(
-                          'Redirecting to',
-                          `${url.origin}/${owner}/${repo}/assets/${asset.id}/${target_file}`,
-                      );
-                      return Response.redirect(
-                          `${url.origin}/${owner}/${repo}/assets/${asset.id}/${target_file}`,
-                           302,
-                      );
                   }
               }
           }

--- a/main.ts
+++ b/main.ts
@@ -27,6 +27,20 @@ Deno.serve(async (req) => {
       target_file = groups[4];
       remote_url = `https://api.github.com/repos/${owner}/${repo}/actions/artifacts/${artifact}/zip`
   }
+  // If not found, look for url like org/repo/assets/xxxxx/file
+  if (remote_url === undefined) {
+      const groups = url.pathname.match(/\/([^\/]*)\/([^\/]*)\/.*assets\/(\d{9})\/?(.*)/);
+      if (groups !== null) {
+          const owner = groups[1];
+          const repo = groups[2];
+          const asset = groups[3];
+          console.log({owner, repo, asset});
+          target_file = groups[4];
+          remote_url = `https://api.github.com/repos/${owner}/${repo}/releases/assets/${asset}`;
+          opts.headers['Accept'] = 'application/octet-stream';
+          opts.redirect = 'follow';
+      }
+  }
   // If not found, look for url like org/repo/branch/file
   // If it matches, find the latest action run in the repo on the branch and use its first artifact
   if (remote_url === undefined) {
@@ -37,48 +51,75 @@ Deno.serve(async (req) => {
           const branch = groups[3];
           console.log({owner, repo, branch});
           target_file = groups[4];
-          try {
-              // Retreive relatively few per page - hopefully we won't need to fetch many anyway, so it won't increase latency much.
-              const per_page = 10;
-              // Retreive runs on branch, for each run, retreive the first artifact that has "docs_html" name.
-              // Assume that one of the first per_page * 10 workflow runs has a docs build.
-              for (let page=1; page < 10; page++) {
-                  const runs = (await (await fetch(
-                      `https://api.github.com/repos/${owner}/${repo}/actions/runs?branch=${branch}&page=${page}&per_page=${per_page}`,
-                      opts,
-                  )).json()).workflow_runs;
-                  for (const run of runs) {
-                      const artifact_names = repo === 'scipp' ? ['docs_html', 'html', 'DocumentationHTML'] : ['docs_html'];
-                      for (const artifact_name of artifact_names) {
-                          const artifacts = (await (await fetch(
-                              `https://api.github.com/repos/${owner}/${repo}/actions/runs/${run.id}/artifacts?name=${artifact_name}&per_page=1`,
-                              opts,
-                          )).json()).artifacts;
-                          if (artifacts.length != 0) {
-                              console.log(
-                                  'Redirecting to',
-                                  `${url.origin}/${owner}/${repo}/actions/artifacts/${artifacts[0].id}/${target_file}`,
-                              );
-                              return Response.redirect(
-                                  `${url.origin}/${owner}/${repo}/actions/artifacts/${artifacts[0].id}/${target_file}`,
-                                   302,
-                              );
-                          }
+
+          if (branch.match(/^v?[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*$/)) {
+              // branch is a release tag name - fetch from release assets
+              const tag = branch[0] == 'v' ? branch.slice(1) : branch;
+              const release = (await (await fetch(
+                  `https://api.github.com/repos/${owner}/${repo}/releases/tags/${tag}`,
+                  opts,
+              )).json());
+              const assets = await (await fetch(release.assets_url)).json();
+              for (const asset of assets) {
+                  if (asset.name.match(/documentation.*/)) {
+                      if (target_file == '') {
+                          target_file = `documentation-${tag}/index.html`;
                       }
-                  }
-                  if (runs.length < per_page) {
-                      // Retreived fewer than requested, we reached the end of the list.
-                      break;
+                      console.log(
+                          'Redirecting to',
+                          `${url.origin}/${owner}/${repo}/assets/${asset.id}/${target_file}`,
+                      );
+                      return Response.redirect(
+                          `${url.origin}/${owner}/${repo}/assets/${asset.id}/${target_file}`,
+                           302,
+                      );
                   }
               }
-              return new Response(
-                  "No docs artifact was found on that branch", { status: 404 }
-              );
-          } catch (e) {
-              console.log("Error when fetching latest docs from branch ", e);
-              return new Response(
-                  "Failed to fetch latest docs from branch", { status: 500 }
-              );
+          }
+          else {
+              try {
+                  // Retreive relatively few per page - hopefully we won't need to fetch many anyway, so it won't increase latency much.
+                  const per_page = 10;
+                  // Retreive runs on branch, for each run, retreive the first artifact that has "docs_html" name.
+                  // Assume that one of the first per_page * 10 workflow runs has a docs build.
+                  for (let page=1; page < 10; page++) {
+                      const runs = (await (await fetch(
+                          `https://api.github.com/repos/${owner}/${repo}/actions/runs?branch=${branch}&page=${page}&per_page=${per_page}`,
+                          opts,
+                      )).json()).workflow_runs;
+                      for (const run of runs) {
+                          const artifact_names = repo === 'scipp' ? ['docs_html', 'html', 'DocumentationHTML'] : ['docs_html'];
+                          for (const artifact_name of artifact_names) {
+                              const artifacts = (await (await fetch(
+                                  `https://api.github.com/repos/${owner}/${repo}/actions/runs/${run.id}/artifacts?name=${artifact_name}&per_page=1`,
+                                  opts,
+                              )).json()).artifacts;
+                              if (artifacts.length != 0) {
+                                  console.log(
+                                      'Redirecting to',
+                                      `${url.origin}/${owner}/${repo}/actions/artifacts/${artifacts[0].id}/${target_file}`,
+                                  );
+                                  return Response.redirect(
+                                      `${url.origin}/${owner}/${repo}/actions/artifacts/${artifacts[0].id}/${target_file}`,
+                                       302,
+                                  );
+                              }
+                          }
+                      }
+                      if (runs.length < per_page) {
+                          // Retreived fewer than requested, we reached the end of the list.
+                          break;
+                      }
+                  }
+                  return new Response(
+                      "No docs artifact was found on that branch", { status: 404 }
+                  );
+              } catch (e) {
+                  console.log("Error when fetching latest docs from branch ", e);
+                  return new Response(
+                      "Failed to fetch latest docs from branch", { status: 500 }
+                  );
+              }
           }
       }
   }

--- a/main.ts
+++ b/main.ts
@@ -38,26 +38,43 @@ Deno.serve(async (req) => {
           console.log({owner, repo, branch});
           target_file = groups[4];
           try {
-              for (let page=1; page < 6; page++) {
-                  const artifacts = (await (await fetch(
-                      `https://api.github.com/repos/${owner}/${repo}/actions/artifacts?name=docs_html&page=${page}`,
+              // Retreive relatively few per page - hopefully we won't need to fetch many anyway, so it won't increase latency much.
+              const per_page = 10;
+              // Retreive runs on branch.
+              // For each run, retreive the first artifact that has "docs_html" name.
+              // Retreive artifacts until we find the latest on branch.
+              // Assume that one of the first per_page * 10 workflow runs has a docs build.
+              for (let page=1; page < 10; page++) {
+                  const runs = (await (await fetch(
+                      `https://api.github.com/repos/${owner}/${repo}/actions/runs?branch=${branch}&page=${page}&per_page=${per_page}`,
                       opts,
-                  )).json()).artifacts;
-                  for (const artifact of artifacts) {
-                      if (artifact.workflow_run.head_branch == branch) {
-                          console.log(
-                              'Redirecting to',
-                              `${url.origin}/${owner}/${repo}/actions/artifacts/${artifact.id}/${target_file}`,
-                          );
-                          return Response.redirect(
-                              `${url.origin}/${owner}/${repo}/actions/artifacts/${artifact.id}/${target_file}`,
-                               302,
-                          );
+                  )).json()).workflow_runs;
+                  for (const run of runs) {
+                      const artifact_names = repo === 'scipp' ? ['docs_html', 'html', 'DocumentationHTML'] : ['docs_html'];
+                      for (const artifact_name of artifact_names) {
+                          const artifacts = (await (await fetch(
+                              `https://api.github.com/repos/${owner}/${repo}/actions/runs/${run.id}/artifacts?name=${artifact_name}&per_page=1`,
+                              opts,
+                          )).json()).artifacts;
+                          if (artifacts.length != 0) {
+                              console.log(
+                                  'Redirecting to',
+                                  `${url.origin}/${owner}/${repo}/actions/artifacts/${artifacts[0].id}/${target_file}`,
+                              );
+                              return Response.redirect(
+                                  `${url.origin}/${owner}/${repo}/actions/artifacts/${artifacts[0].id}/${target_file}`,
+                                   302,
+                              );
+                          }
                       }
+                  }
+                  if (runs.length < per_page) {
+                      // Retreived fewer than requested, we reached the end of the list.
+                      break;
                   }
               }
               return new Response(
-                  "No recent docs artifact found on that branch", { status: 404 }
+                  "No docs artifact was found on that branch", { status: 404 }
               );
           } catch (e) {
               console.log("Error when fetching latest docs from branch ", e);


### PR DESCRIPTION
This PR contains two improvements:

1. Instead of just looping over all artifacts until we find one docs build with the matching branch name, now we loop over the runs on the requested branch, and locate the first docs artifact in those. The motivation for this is that we will make fewer api requests, especially when fetching docs from a tag or branch that did not have a docs build for a long time.
2. A special case was added so that we look for the artifact names used for docs in the scipp repo.

Staging url with these changes: https://remote-unzip-b07vck3zjbv2.deno.dev/

Unfortunately it still does not work for old releases, because even if the docs builds are stored somewhere, they are not available at the artifacts url associated with the run, old builds return a 410 Gone status code.
Maybe there's a way to work around that, but for now I'll just leave it like that.