### PR TITLE
feat: allow selecting what artifact name to look for

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -90,7 +90,11 @@ Deno.serve(async (req) => {
                           opts,
                       )).json()).workflow_runs;
                       for (const run of runs) {
-                          const artifact_names = repo === 'scipp' ? ['docs_html', 'html', 'DocumentationHTML'] : ['docs_html'];
+                          const artifact_names = (
+                              url.searchParams.has('artifact_name') ?
+                              url.searchParams.get('artifact_name').split(',') :
+                              (repo === 'scipp' ? ['docs_html', 'html', 'DocumentationHTML'] : ['docs_html'])
+                          );
                           for (const artifact_name of artifact_names) {
                               const artifacts = (await (await fetch(
                                   `https://api.github.com/repos/${owner}/${repo}/actions/runs/${run.id}/artifacts?name=${artifact_name}&per_page=1`,


### PR DESCRIPTION
If you select a branch to look at the latest docs for, for example "http://remote-unzip.deno.dev/scipp/ess/main", then remote-unzip currently looks for the most recent artifact with the name `docs-html`.

In the case of scipp/ess/main, there is no artifact with that name, so you will see 404.

This change adds a `artifact_name` query parameter that lets you select the name of the artifact to look for:
http://remote-unzip.deno.dev/scipp/ess/main?artifact_name=docs-essimaging